### PR TITLE
improved and additional omeroidr.images.Images and omeroidr.data.Data methods

### DIFF
--- a/omeroidr/constants.py
+++ b/omeroidr/constants.py
@@ -10,12 +10,17 @@ API_LOGOUT = '/webclient/logout/'
 API_PLATES = '/webclient/api/plates/?id={screenId}'
 # List of all wells in a plate
 API_PLATE = '/webgateway/plate/{id}'
-# Annotation for a well
+# Annotation for a well field
 API_WELL_ANNOTATIONS = '/webclient/api/annotations/?type={type}&image={id}'
 # Table for a well
 API_WELL_TABLES = '/webgateway/table/Screen.plateLinks.child.wells/{wellId}/query/?query=Well-{wellId}'
-# Image for a well
-API_IMAGE = '/webclient/render_image/{id}'
-
+# Image for a well filed
+API_IMAGE = '/webclient/render_image/{id}/{z}/{t}/'
+# Image per channel for a well filed
+API_IMAGE_CHANNEL = '/webclient/render_split_channel/{id}/{z}/{t}/'
+# Image thumbnale
+API_IMAGE_THUMBNALE = '/webgateway/render_thumbnail/{id}/{w}/?z={z}&t={t}/'
+# Image data in json file format
+API_IMAGE_DATA = '/webgateway/imgData/{id}/'
 # Annotation types, used in conjunction with API_WELL_ANNOTATIONS
 API_WELL_ANNOTATION_TYPES = ['tag', 'map', 'file', 'rating', 'comment', 'custom']

--- a/omeroidr/data.py
+++ b/omeroidr/data.py
@@ -1,6 +1,6 @@
 import json
 import requests
-from omeroidr.constants import API_WELL_ANNOTATIONS, API_WELL_ANNOTATION_TYPES, API_PLATE, API_PLATES, API_WELL_TABLES
+from omeroidr.constants import API_WELL_ANNOTATIONS, API_WELL_ANNOTATION_TYPES, API_PLATE, API_PLATES, API_WELL_TABLES, API_IMAGE_DATA
 
 class Data:
     def __init__(self, session, base_url: str):
@@ -90,3 +90,20 @@ class Data:
 
         # merge annotations
         return dict(well, **annotations)
+
+
+    def get_imagedata(self, image_id: int) -> dict:
+        """
+        Get all the associated metadata for an OMERO image
+
+        :param image_id: The id of the image to fetch metadata
+        :return: Dict of the image metadata
+        """
+        # set empty output
+        d_json = None
+
+        # get image metadata
+        url = self.base_url + API_IMAGE_DATA.format(id=image_id)
+        d_json = self.get_json(url)
+        # output
+        return(d_json)

--- a/omeroidr/images.py
+++ b/omeroidr/images.py
@@ -1,6 +1,6 @@
 import os
 import requests
-from omeroidr.constants import API_IMAGE
+from omeroidr.constants import API_IMAGE, API_IMAGE_CHANNEL, API_IMAGE_THUMBNALE
 
 class Images:
 
@@ -14,15 +14,26 @@ class Images:
         self.base_url = base_url
         self.save_path = save_path
 
-    def download_image(self, image_id: int):
+
+    def download_image(self, image_id: int, z=0, t=0, render_setting="", explicit=False) -> str:
         """
         retrieve and save OMERO image
 
         :param image_id: The id of the image to fetch
+        :param z: The z stack number of the image to fetch
+        :param t: The t time serial number of the image to fetch
+        :param explicit: if True, filename will even in the default case contaon z value, t value and render setting.
+        :return: Filename string
         """
-        fname = os.path.join(self.save_path, '{0}.jpg'.format(image_id))
-        if not os.path.isfile(fname):
-            downloadLink = self.base_url + API_IMAGE.format(id=image_id)
+        # filename
+        if explicit or (z !=0) or (t !=0) or (len(render_setting) > 0):
+            fname = os.path.join(self.save_path, '{}_z{}_t{}{}.jpg'.format(image_id,z,t,render_setting))
+        else:
+            fname = os.path.join(self.save_path, '{}.jpg'.format(image_id))
+
+        # if file not yet downloaded
+        if not os.path.isfile(fname) or len(render_setting) > 0:
+            downloadLink = self.base_url + API_IMAGE.format(id=image_id,z=z,t=t) + render_setting
 
             # open web handle
             r = self.session.get(downloadLink, stream=True)
@@ -33,3 +44,72 @@ class Images:
                    fd.write(o_chunk)
             fd.close()
 
+        # return file name
+        return(fname)
+
+
+    def download_imagechannel(self, image_id: int, z=0, t=0, render_setting="", explicit=False) -> str:
+        """
+        retrieve and save OMERO image, each active channel in a separate panel
+
+        :param image_id: The id of the image to fetch
+        :param z: The z stack number of the image to fetch
+        :param t: The t time serial number of the image to fetch
+        :param explicit: if True, filename will even in the default case contaon z value, t value and render setting.
+        :return: Filename string
+        """
+        # filename
+        if explicit or (z !=0) or (t !=0) or (len(render_setting) > 0):
+            fname = os.path.join(self.save_path, '{}channel_z{}_t{}{}.jpg'.format(image_id,z,t,render_setting))
+        else:
+            fname = os.path.join(self.save_path, '{}channel.jpg'.format(image_id))
+
+        # if file not yet downloaded
+        if not os.path.isfile(fname) or len(render_setting) > 0:
+            downloadLink = self.base_url + API_IMAGE_CHANNEL.format(id=image_id,z=z,t=t) + render_setting
+
+            # open web handle
+            r = self.session.get(downloadLink, stream=True)
+
+            # write file
+            with open(fname, 'wb') as fd:
+               for o_chunk in r.iter_content(chunk_size=1024):
+                   fd.write(o_chunk)
+            fd.close()
+
+        # return file name
+        return(fname)
+
+
+    def download_imagethumb(self, image_id: int, w=64, z=0, t=0, explicit=False) -> str:
+        """
+        retrieve and save OMERO thumbnale image
+
+        :param image_id: The id of the image to fetch
+        :param w: The thumbnale width
+        :param z: The z stack number of the image to fetch
+        :param t: The t time serial number of the image to fetch
+        :param explicit: if True, filename will even in the default case contaon z value, t value and render setting.
+        :return: Filename string
+        """
+        # filename
+        if explicit or (w != 64) or (z !=0) or (t !=0):
+            fname = os.path.join(self.save_path, '{}thumbnale_w{}_z{}_t{}.jpg'.format(image_id, w, z, t))
+        else:
+            fname = os.path.join(self.save_path, '{}thumbnale.jpg'.format(image_id))
+
+        # if file not yet downloaded
+        if not os.path.isfile(fname):
+            downloadLink = self.base_url + API_IMAGE_THUMBNALE.format(id=image_id, w=w, z=z, t=t)
+
+            # open web handle
+            r = self.session.get(downloadLink, stream=True)
+
+            # write file
+            with open(fname, 'wb') as fd:
+               for o_chunk in r.iter_content(chunk_size=1024):
+                   fd.write(o_chunk)
+            fd.close()
+
+        # return file name
+        return(fname)


### PR DESCRIPTION
this brach contains:

1) a more powerful Images.download_image method which allow z, t and render settings. however, the default explicit=False setting make sure that code which relies on the pre-branch version not breaks.

2) a Images.download_imagechannel method for retrieving jpegs which layout each active channel in a separate panel and an Images.download_imagethumb method for retrieving thumbnail images.

3) a Data.get_imagedata method to retrieve image related metadata.

implementation is an adaption from the render_image, render_split_channels, render_thumbnail and imgData webgateway methods, found in the official documentation:
https://www.openmicroscopy.org/site/support/omero5.2/developers/Web/WebGateway.html
